### PR TITLE
Navigation Handlers - part 2 of 2

### DIFF
--- a/ColorApp/Base.lproj/Main.storyboard
+++ b/ColorApp/Base.lproj/Main.storyboard
@@ -326,7 +326,7 @@
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
-                                    <segue destination="oB6-WC-ClM" kind="show" id="8Ag-Jj-2cV"/>
+                                    <action selector="loadColorButonSingleTapped:" destination="vXZ-lx-hvc" eventType="touchDown" id="aOY-Yz-GId"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/ColorApp/Base.lproj/Main.storyboard
+++ b/ColorApp/Base.lproj/Main.storyboard
@@ -118,7 +118,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fa1-ka-a3l">
-                                <rect key="frame" x="16" y="303.5" width="288" height="124"/>
+                                <rect key="frame" x="16" y="303" width="288" height="125"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="20"/>
                                 <state key="normal" title="Hue Picker">
@@ -126,11 +126,11 @@
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
-                                    <segue destination="vXZ-lx-hvc" kind="show" id="tub-iW-EsX"/>
+                                    <action selector="colorPickerButtonSingleTapped:" destination="Ox9-J7-pXq" eventType="touchDown" id="zL0-pS-gUM"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nlU-Mr-qUR">
-                                <rect key="frame" x="16" y="435.5" width="288" height="124.5"/>
+                                <rect key="frame" x="16" y="436" width="288" height="124"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="20"/>
                                 <state key="normal" title="Hue Collection">
@@ -142,7 +142,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qXW-a2-tdT">
-                                <rect key="frame" x="16" y="171" width="288" height="124.5"/>
+                                <rect key="frame" x="16" y="171" width="288" height="124"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="20"/>
                                 <state key="normal" title="Hue Extractor">
@@ -447,14 +447,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="5Er-tN-fdw">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                                <rect key="frame" x="0.0" y="-44" width="320" height="612"/>
                                 <color key="backgroundColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <prototypes>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="PGp-Jb-wjF">
                                         <rect key="frame" x="0.0" y="22" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="PGp-Jb-wjF" id="z8K-kD-Ha1">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <color key="backgroundColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </tableViewCellContentView>
@@ -553,11 +553,11 @@
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nye-OL-nmP" userLabel="Hue Pane Swatch View 2">
-                                        <rect key="frame" x="68" y="8" width="51.5" height="34"/>
+                                        <rect key="frame" x="68" y="8" width="52" height="34"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PaD-vS-B4p" userLabel="Hue Pane Swatch View 3">
-                                        <rect key="frame" x="127.5" y="8" width="52" height="34"/>
+                                        <rect key="frame" x="128" y="8" width="51" height="34"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ttt-nd-ACJ" userLabel="Hue Pane Save Hue Button">
@@ -573,7 +573,7 @@
                                         </connections>
                                     </button>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bED-W7-znl" userLabel="Hue Pane Swatch View 4">
-                                        <rect key="frame" x="187.5" y="8" width="51.5" height="34"/>
+                                        <rect key="frame" x="187" y="8" width="52" height="34"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </view>
                                 </subviews>

--- a/ColorApp/Base.lproj/Main.storyboard
+++ b/ColorApp/Base.lproj/Main.storyboard
@@ -138,7 +138,7 @@
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
-                                    <segue destination="2KI-fO-8HL" kind="show" id="byu-NP-wrL"/>
+                                    <action selector="colorCollectionButtonSingleTapped:" destination="Ox9-J7-pXq" eventType="touchDown" id="MdF-g7-5IJ"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qXW-a2-tdT">
@@ -502,7 +502,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="cnn-4s-7rc">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                                <rect key="frame" x="0.0" y="-44" width="320" height="612"/>
                                 <color key="backgroundColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <connections>
                                     <outlet property="dataSource" destination="2KI-fO-8HL" id="ei4-kJ-Ya2"/>

--- a/ColorApp/ViewControllers/ColorMenuViewController.m
+++ b/ColorApp/ViewControllers/ColorMenuViewController.m
@@ -68,6 +68,13 @@
     [self presentViewController:actionSheetAlertController animated:YES completion:nil];
 }
 
+- (IBAction)colorPickerButtonSingleTapped:(id)sender {
+    HHPickerNavigationHandler *pickerNavigationHandler = [[HHPickerNavigationHandler alloc] initWithNavigationController:self.navigationController
+                                                                                                                animated:true
+                                                                                                              storyboard:self.storyboard];
+    [pickerNavigationHandler handleNavigation];
+}
+
 #pragma mark -- UIImagePickerViewController delegate methods
 
 // after the image source has been determined, that data is sent to the ColorExtractorVC to be worked with

--- a/ColorApp/ViewControllers/ColorMenuViewController.m
+++ b/ColorApp/ViewControllers/ColorMenuViewController.m
@@ -27,6 +27,8 @@
                                                                      // informing them of the tip system
 }
 
+#pragma mark -- Button Actions
+
 - (IBAction)showInfoButtonTipSelector:(id)sender {
     [tipsMethodsClassInstance showInfoButtonTipWithTipNumber:0
                                             inViewController:self];
@@ -70,9 +72,16 @@
 
 - (IBAction)colorPickerButtonSingleTapped:(id)sender {
     HHPickerNavigationHandler *pickerNavigationHandler = [[HHPickerNavigationHandler alloc] initWithNavigationController:self.navigationController
-                                                                                                                animated:true
+                                                                                                                animated:YES
                                                                                                               storyboard:self.storyboard];
     [pickerNavigationHandler handleNavigation];
+}
+
+- (IBAction)colorCollectionButtonSingleTapped:(id)sender {
+    HHSavedNavigationHandler *savedNavigationHandler = [[HHSavedNavigationHandler alloc] initWithNavigationController:self.navigationController
+                                                                                                             animated:YES
+                                                                                                           storyboard:self.storyboard];
+    [savedNavigationHandler handleNavigation];
 }
 
 #pragma mark -- UIImagePickerViewController delegate methods
@@ -85,7 +94,8 @@
         UIImage *editedImage = info[UIImagePickerControllerEditedImage];
         
         HHExtractorNavigationHandler *extractorNavigationHandler = [[HHExtractorNavigationHandler alloc] initWithNavigationController:self.navigationController
-                                                                                                                             animated:true image:editedImage
+                                                                                                                             animated:YES
+                                                                                                                                image:editedImage
                                                                                                                            storyboard:self.storyboard];
         [extractorNavigationHandler handleNavigation];
     }

--- a/ColorApp/ViewControllers/ColorMenuViewController.m
+++ b/ColorApp/ViewControllers/ColorMenuViewController.m
@@ -10,6 +10,8 @@
 
 #import "ColorMenuViewController.h"
 
+#import "ColorApp-Swift.h"
+
 @interface ColorMenuViewController () {
     TipsMethods *tipsMethodsClassInstance;
 }
@@ -75,11 +77,10 @@
     if ([mediaType isEqualToString:(NSString *)kUTTypeImage]) {
         UIImage *editedImage = info[UIImagePickerControllerEditedImage];
         
-        // instantiate VC in NavCon, set property to editedImage and push
-        ColorExtractorViewController *vc = [self.storyboard instantiateViewControllerWithIdentifier:@"ColorExtractorViewController"];
-        vc.chosenImage = editedImage;
-        
-        [self.navigationController pushViewController:vc animated:YES];
+        HHExtractorNavigationHandler *extractorNavigationHandler = [[HHExtractorNavigationHandler alloc] initWithNavigationController:self.navigationController
+                                                                                                                             animated:true image:editedImage
+                                                                                                                           storyboard:self.storyboard];
+        [extractorNavigationHandler handleNavigation];
     }
     
     [self dismissViewControllerAnimated:YES completion:nil];

--- a/ColorApp/ViewControllers/ColorPickerViewController.m
+++ b/ColorApp/ViewControllers/ColorPickerViewController.m
@@ -10,6 +10,8 @@
 
 #import "ColorPickerViewController.h"
 
+#import "ColorApp-Swift.h"
+
 @interface ColorPickerViewController () {
     NSMutableArray *colorSwatchViews;
     NSInteger selectedColorSwatchView;
@@ -175,6 +177,16 @@
     }
 }
 
+#pragma mark -- IBActions
+
+- (IBAction)loadColorButonSingleTapped:(id)sender {
+    HHLoadNavigationHandler *loadNavigationHandler = [[HHLoadNavigationHandler alloc] initWithNavigationController:self.navigationController
+                                                                                                          animated:YES
+                                                                                   loadColorDelegateViewController:self
+                                                                                                        storyboard:self.storyboard];
+    [loadNavigationHandler handleNavigation];
+}
+
 // Presents a UIAlertController allowing the user to give their new color a name
 // before saving it to the phone
 - (IBAction)saveHue:(id)sender {
@@ -240,15 +252,6 @@
                                                           alpha:hueValues[3]/100.f];
     
     [self updateColorSliders:colorSwatchToUpdate];
-}
-
-#pragma mark -- Navigation
-
--(void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender{
-    
-    LoadColorViewController *loadColorVC =(LoadColorViewController*)segue.destinationViewController;
-    loadColorVC.delegate = self;
-    
 }
 
 @end

--- a/ColorApp/ViewControllers/LoadColorViewController.m
+++ b/ColorApp/ViewControllers/LoadColorViewController.m
@@ -11,6 +11,8 @@
 
 #import "LoadColorViewController.h"
 
+#import "ColorApp-Swift.h"
+
 @interface LoadColorViewController () {
     TipsMethods *tipsMethodsClassInstance;
 }
@@ -105,7 +107,10 @@
     hueValues[3] = [[self.alphaval objectAtIndex:indexPath.row] floatValue];
     
     [self.delegate returnHueValues:hueValues];
-    [self.navigationController popViewControllerAnimated:YES];
+    
+    HHLoadedNavigationHandler *loadedNavigationHandler = [[HHLoadedNavigationHandler alloc] initWithNavigationController:self.navigationController
+                                                                                                                animated:YES];
+    [loadedNavigationHandler handleNavigation];
 }
 
 @end


### PR DESCRIPTION
Second part of https://github.com/triflingnome/ColorApp/pull/4

**Description**

This PR replaces any previous navigation either through storyboard segues or programmatic pushing or popping of the `navigationController` with instances of classes that conform to `HHNavigationHandleable`

**Testing**
- Menu to Extractor: Dev tested
- Menu to Picker: Dev tested
- Menu to Collection: Dev tested
- Picker to Load: Dev tested
- Load to Picker: Dev tested