### PR TITLE
Hue Model

### DIFF
--- a/ColorApp.xcodeproj/project.pbxproj
+++ b/ColorApp.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B40866ED1DDFADCA00E7271A /* UIColor+RGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40866EC1DDFADCA00E7271A /* UIColor+RGB.swift */; };
+		B40866F01DDFB75200E7271A /* UIColor+RGBTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40866EF1DDFB75100E7271A /* UIColor+RGBTest.swift */; };
 		B47E26511DDF7E4B003E8591 /* HHHueModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47E26501DDF7E4B003E8591 /* HHHueModel.swift */; };
 		B47E26541DDF7E6B003E8591 /* HHHueModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47E26531DDF7E6B003E8591 /* HHHueModelTest.swift */; };
 		B49738781B41DAFE00E09E5E /* LoadColorViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B49738771B41DAFE00E09E5E /* LoadColorViewController.m */; };
@@ -57,6 +59,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B40866EC1DDFADCA00E7271A /* UIColor+RGB.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+RGB.swift"; sourceTree = "<group>"; };
+		B40866EF1DDFB75100E7271A /* UIColor+RGBTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+RGBTest.swift"; sourceTree = "<group>"; };
 		B40B48731DD7F888009F6E9C /* ColorApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ColorApp-Bridging-Header.h"; sourceTree = "<group>"; };
 		B47E26501DDF7E4B003E8591 /* HHHueModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HHHueModel.swift; sourceTree = "<group>"; };
 		B47E26531DDF7E6B003E8591 /* HHHueModelTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HHHueModelTest.swift; sourceTree = "<group>"; };
@@ -136,10 +140,27 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		B40866EB1DDFADA000E7271A /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				B40866EC1DDFADCA00E7271A /* UIColor+RGB.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		B40866EE1DDFB72F00E7271A /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				B40866EF1DDFB75100E7271A /* UIColor+RGBTest.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		B40B48711DD7F82F009F6E9C /* HueHarnesser */ = {
 			isa = PBXGroup;
 			children = (
 				B4F5CF671DDD433C00179F98 /* Constants */,
+				B40866EB1DDFADA000E7271A /* Extensions */,
 				B47E264F1DDF7E17003E8591 /* Model */,
 				B4F5CF591DDD3A5400179F98 /* NavigationHandler */,
 				B4F5CF561DDB80E200179F98 /* Foundation */,
@@ -317,6 +338,7 @@
 		B4F5CF6A1DDE203600179F98 /* HueHarnesser */ = {
 			isa = PBXGroup;
 			children = (
+				B40866EE1DDFB72F00E7271A /* Extension */,
 				B47E26521DDF7E56003E8591 /* Model */,
 				B4F5CF6B1DDE205400179F98 /* NavigationHandler */,
 			);
@@ -446,6 +468,7 @@
 				B4F5CF5B1DDD3A8500179F98 /* HHExtractorNavigationHandler.swift in Sources */,
 				B4A3D6C01B4C4D2B00C701BE /* Constants.m in Sources */,
 				B49B986E1B22162300176FA6 /* main.m in Sources */,
+				B40866ED1DDFADCA00E7271A /* UIColor+RGB.swift in Sources */,
 				B4F5CF611DDD3AF700179F98 /* HHLoadNavigationHandler.swift in Sources */,
 				B499DB5E1B443EFC006E174A /* LoadColorTableViewCell.m in Sources */,
 				B499DB631B44493D006E174A /* SavedColorsTableViewCell.m in Sources */,
@@ -471,6 +494,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B40866F01DDFB75200E7271A /* UIColor+RGBTest.swift in Sources */,
 				B47E26541DDF7E6B003E8591 /* HHHueModelTest.swift in Sources */,
 				B4F5CF701DDE20BE00179F98 /* HHLoadNavigationHandlerTest.swift in Sources */,
 				B4F5CF721DDE20E300179F98 /* HHLoadedNavigationHandlerTest.swift in Sources */,

--- a/ColorApp.xcodeproj/project.pbxproj
+++ b/ColorApp.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B47E26511DDF7E4B003E8591 /* HHHueModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47E26501DDF7E4B003E8591 /* HHHueModel.swift */; };
+		B47E26541DDF7E6B003E8591 /* HHHueModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47E26531DDF7E6B003E8591 /* HHHueModelTest.swift */; };
 		B49738781B41DAFE00E09E5E /* LoadColorViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B49738771B41DAFE00E09E5E /* LoadColorViewController.m */; };
 		B499DB5E1B443EFC006E174A /* LoadColorTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = B499DB5C1B443EFC006E174A /* LoadColorTableViewCell.m */; };
 		B499DB5F1B443EFC006E174A /* LoadColorTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B499DB5D1B443EFC006E174A /* LoadColorTableViewCell.xib */; };
@@ -56,6 +58,8 @@
 
 /* Begin PBXFileReference section */
 		B40B48731DD7F888009F6E9C /* ColorApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ColorApp-Bridging-Header.h"; sourceTree = "<group>"; };
+		B47E26501DDF7E4B003E8591 /* HHHueModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HHHueModel.swift; sourceTree = "<group>"; };
+		B47E26531DDF7E6B003E8591 /* HHHueModelTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HHHueModelTest.swift; sourceTree = "<group>"; };
 		B49738761B41DAFE00E09E5E /* LoadColorViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoadColorViewController.h; sourceTree = "<group>"; };
 		B49738771B41DAFE00E09E5E /* LoadColorViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LoadColorViewController.m; sourceTree = "<group>"; };
 		B499DB5B1B443EFC006E174A /* LoadColorTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoadColorTableViewCell.h; sourceTree = "<group>"; };
@@ -136,11 +140,28 @@
 			isa = PBXGroup;
 			children = (
 				B4F5CF671DDD433C00179F98 /* Constants */,
+				B47E264F1DDF7E17003E8591 /* Model */,
 				B4F5CF591DDD3A5400179F98 /* NavigationHandler */,
 				B4F5CF561DDB80E200179F98 /* Foundation */,
 				B40B48731DD7F888009F6E9C /* ColorApp-Bridging-Header.h */,
 			);
 			path = HueHarnesser;
+			sourceTree = "<group>";
+		};
+		B47E264F1DDF7E17003E8591 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				B47E26501DDF7E4B003E8591 /* HHHueModel.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		B47E26521DDF7E56003E8591 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				B47E26531DDF7E6B003E8591 /* HHHueModelTest.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		B499DB591B443EC5006E174A /* SavedColorsTableViewCell */ = {
@@ -296,6 +317,7 @@
 		B4F5CF6A1DDE203600179F98 /* HueHarnesser */ = {
 			isa = PBXGroup;
 			children = (
+				B47E26521DDF7E56003E8591 /* Model */,
 				B4F5CF6B1DDE205400179F98 /* NavigationHandler */,
 			);
 			path = HueHarnesser;
@@ -432,6 +454,7 @@
 				B4D2B2EB1B3893D800049922 /* SavedHues.xcdatamodeld in Sources */,
 				B4A3D6B41B4B6C0B00C701BE /* TipsMethods.m in Sources */,
 				B49D156D1B38735400E7CA0F /* ColorAppNavigationController.m in Sources */,
+				B47E26511DDF7E4B003E8591 /* HHHueModel.swift in Sources */,
 				B4A3D6B11B4B6AB700C701BE /* ColorOptionsViewController.m in Sources */,
 				B4F5CF5F1DDD3AD600179F98 /* HHSavedNavigationHandler.swift in Sources */,
 				B49738781B41DAFE00E09E5E /* LoadColorViewController.m in Sources */,
@@ -448,6 +471,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B47E26541DDF7E6B003E8591 /* HHHueModelTest.swift in Sources */,
 				B4F5CF701DDE20BE00179F98 /* HHLoadNavigationHandlerTest.swift in Sources */,
 				B4F5CF721DDE20E300179F98 /* HHLoadedNavigationHandlerTest.swift in Sources */,
 				B4F5CF6E1DDE209400179F98 /* HHExtractorNavigationHandlerTest.swift in Sources */,

--- a/ColorAppTests/HueHarnesser/Extension/UIColor+RGBTest.swift
+++ b/ColorAppTests/HueHarnesser/Extension/UIColor+RGBTest.swift
@@ -1,0 +1,54 @@
+//
+//  UIColor+RGBTest.swift
+//  ColorApp
+//
+//  Created by Michael Berg on 11/18/16.
+//  Copyright © 2016 Michael Berg. All rights reserved.
+//
+
+import XCTest
+
+@testable import ColorApp
+
+class UIColor_RGBTest: XCTestCase {
+    
+    func testRGBADictionary() {
+        let expectedRedValue: CGFloat = 50
+        let expectedGreenValue: CGFloat = 220
+        let expectedBlueValue: CGFloat = 50
+        let expectedAlphaValue: CGFloat = 100
+        
+        let expectedColor = UIColor(red: expectedRedValue / 255,
+                                    green: expectedGreenValue / 255,
+                                    blue: expectedBlueValue / 255,
+                                    alpha: expectedAlphaValue / 100)
+        let actualValues = expectedColor.rgbaDictionary()
+        
+        if let actualValues = actualValues {
+            XCTAssertEqual(expectedRedValue, actualValues["red"])
+            XCTAssertEqual(expectedGreenValue, actualValues["green"])
+            XCTAssertEqual(expectedBlueValue, actualValues["blue"])
+            XCTAssertEqual(expectedAlphaValue, actualValues["alpha"])
+        } else {
+            XCTFail("RGBA values aren't returning correctly")
+        }
+    }
+    
+    func testHueModel() {
+        let expectedHue = HHHueModel(name: "Hue", cgRedValue: 35, cgGreenValue: 100, cgBlueValue: 220, cgAlphaValue: 100)
+        let expectedColor = expectedHue.color
+        
+        let actualHue = expectedColor.hueModel()
+        
+        if let actualHue = actualHue {
+            XCTAssertEqual(expectedHue.name, actualHue.name)
+            XCTAssertEqual(expectedHue.redValue, actualHue.redValue)
+            XCTAssertEqual(expectedHue.greenValue, actualHue.greenValue)
+            XCTAssertEqual(expectedHue.blueValue, actualHue.blueValue)
+            XCTAssertEqual(expectedHue.alphaValue, actualHue.alphaValue)
+        } else {
+            XCTFail("Hue model not returning correctly")
+        }
+    }
+    
+}

--- a/ColorAppTests/HueHarnesser/Model/HHHueModelTest.swift
+++ b/ColorAppTests/HueHarnesser/Model/HHHueModelTest.swift
@@ -1,0 +1,7 @@
+//
+//  HHHueModelTest.swift
+//  ColorApp
+//
+//  Created by Michael Berg on 11/18/16.
+//  Copyright © 2016 Michael Berg. All rights reserved.
+//

--- a/ColorAppTests/HueHarnesser/Model/HHHueModelTest.swift
+++ b/ColorAppTests/HueHarnesser/Model/HHHueModelTest.swift
@@ -5,3 +5,32 @@
 //  Created by Michael Berg on 11/18/16.
 //  Copyright © 2016 Michael Berg. All rights reserved.
 //
+
+import XCTest
+
+@testable import ColorApp
+
+class HHHueModelTest: XCTestCase {
+    
+    func testColor() {
+        let expectedRed: CGFloat = 210
+        let expectedGreen: CGFloat = 50
+        let expectedBlue: CGFloat = 100
+        let expectedAlpha: CGFloat = 85
+        
+        let expectedHue = HHHueModel(name: "Test Hue", cgRedValue: expectedRed, cgGreenValue: expectedGreen, cgBlueValue: expectedBlue, cgAlphaValue: expectedAlpha)
+        let color = expectedHue.color
+
+        let actualValues = color.rgbaDictionary()
+        
+        if let actualValues = actualValues {
+            XCTAssertEqual(expectedRed, actualValues["red"])
+            XCTAssertEqual(expectedGreen, actualValues["green"])
+            XCTAssertEqual(expectedBlue, actualValues["blue"])
+            XCTAssertEqual(expectedAlpha, actualValues["alpha"])
+        } else {
+            XCTFail("RGBA values aren't returning correctly")
+        }
+    }
+    
+}

--- a/HueHarnesser/Extensions/UIColor+RGB.swift
+++ b/HueHarnesser/Extensions/UIColor+RGB.swift
@@ -1,0 +1,54 @@
+//
+//  UIColor+RGB.swift
+//  ColorApp
+//
+//  Created by Michael Berg on 11/18/16.
+//  Copyright © 2016 Michael Berg. All rights reserved.
+//
+// Reference for this extension: http://stackoverflow.com/questions/28644311/how-to-get-the-rgb-code-int-from-an-uicolor-in-swift
+
+extension UIColor {
+    
+    func rgbaDictionary() -> [String: CGFloat]? {
+        var initialRedValue: CGFloat = 0
+        var initialGreenValue: CGFloat = 0
+        var initialBlueValue: CGFloat = 0
+        var initialAlphaValue: CGFloat = 0
+        
+        if self.getRed(&initialRedValue, green: &initialGreenValue, blue: &initialBlueValue, alpha: &initialAlphaValue) {
+            let finalRedValue = CGFloat(initialRedValue * 255.0)
+            let finalGreenValue = CGFloat(initialGreenValue * 255.0)
+            let finalBlueValue = CGFloat(initialBlueValue * 255.0)
+            let finalAlphaValue = CGFloat(initialAlphaValue * 100.0)
+            
+            var rgbaDictionary = [String: CGFloat]()
+            rgbaDictionary["red"] = finalRedValue
+            rgbaDictionary["green"] = finalGreenValue
+            rgbaDictionary["blue"] = finalBlueValue
+            rgbaDictionary["alpha"] = finalAlphaValue
+            
+            return rgbaDictionary
+        } else {
+            return nil
+        }
+    }
+    
+    func hueModel() -> HHHueModel? {
+        var initialRedValue: CGFloat = 0
+        var initialGreenValue: CGFloat = 0
+        var initialBlueValue: CGFloat = 0
+        var initialAlphaValue: CGFloat = 0
+        
+        if self.getRed(&initialRedValue, green: &initialGreenValue, blue: &initialBlueValue, alpha: &initialAlphaValue) {
+            let finalRedValue = CGFloat(initialRedValue * 255)
+            let finalGreenValue = CGFloat(initialGreenValue * 255)
+            let finalBlueValue = CGFloat(initialBlueValue * 255)
+            let finalAlphaValue = CGFloat(initialAlphaValue * 100)
+            
+            return HHHueModel(name: "Hue", cgRedValue: finalRedValue, cgGreenValue: finalGreenValue, cgBlueValue: finalBlueValue, cgAlphaValue: finalAlphaValue)
+        } else {
+            return nil
+        }
+    }
+    
+}

--- a/HueHarnesser/Model/HHHueModel.swift
+++ b/HueHarnesser/Model/HHHueModel.swift
@@ -1,0 +1,7 @@
+//
+//  HHHueModel.swift
+//  ColorApp
+//
+//  Created by Michael Berg on 11/18/16.
+//  Copyright © 2016 Michael Berg. All rights reserved.
+//

--- a/HueHarnesser/Model/HHHueModel.swift
+++ b/HueHarnesser/Model/HHHueModel.swift
@@ -17,20 +17,28 @@
     let alphaValue: NSNumber
     
     var color: UIColor {
-        return UIColor(red: CGFloat(redValue.floatValue) / CGFloat(255),
-                       green: CGFloat(greenValue.floatValue) / CGFloat(255),
-                       blue: CGFloat(blueValue.floatValue) / CGFloat(255),
-                       alpha: CGFloat(alphaValue.floatValue) / CGFloat(100))
+        return UIColor(red: CGFloat(redValue.doubleValue) / CGFloat(255),
+                       green: CGFloat(greenValue.doubleValue) / CGFloat(255),
+                       blue: CGFloat(blueValue.doubleValue) / CGFloat(255),
+                       alpha: CGFloat(alphaValue.doubleValue) / CGFloat(100))
     }
     
     // MARK: Inits
     
-    init(name: String, redValue: NSNumber, greenValue: NSNumber, blueValue: NSNumber, alphaValue: NSNumber) {
+    init(name: String, redValue: Double, greenValue: Double, blueValue: Double, alphaValue: Double) {
         self.name = name
-        self.redValue = redValue
-        self.greenValue = greenValue
-        self.blueValue = blueValue
-        self.alphaValue = alphaValue
+        self.redValue = NSNumber(value: redValue)
+        self.greenValue = NSNumber(value: greenValue)
+        self.blueValue = NSNumber(value: blueValue)
+        self.alphaValue = NSNumber(value: alphaValue)
+    }
+    
+    init(name: String, cgRedValue: CGFloat, cgGreenValue: CGFloat, cgBlueValue: CGFloat, cgAlphaValue: CGFloat) {
+        self.name = name
+        self.redValue = NSNumber(value: Double(cgRedValue))
+        self.greenValue = NSNumber(value: Double(cgGreenValue))
+        self.blueValue = NSNumber(value: Double(cgBlueValue))
+        self.alphaValue = NSNumber(value: Double(cgAlphaValue))
     }
     
 }

--- a/HueHarnesser/Model/HHHueModel.swift
+++ b/HueHarnesser/Model/HHHueModel.swift
@@ -5,3 +5,32 @@
 //  Created by Michael Berg on 11/18/16.
 //  Copyright © 2016 Michael Berg. All rights reserved.
 //
+
+@objc class HHHueModel: NSObject {
+    
+    // MARK: Properties
+    
+    let name: String
+    let redValue: NSNumber
+    let greenValue: NSNumber
+    let blueValue: NSNumber
+    let alphaValue: NSNumber
+    
+    var color: UIColor {
+        return UIColor(red: CGFloat(redValue.floatValue) / CGFloat(255),
+                       green: CGFloat(greenValue.floatValue) / CGFloat(255),
+                       blue: CGFloat(blueValue.floatValue) / CGFloat(255),
+                       alpha: CGFloat(alphaValue.floatValue) / CGFloat(100))
+    }
+    
+    // MARK: Inits
+    
+    init(name: String, redValue: NSNumber, greenValue: NSNumber, blueValue: NSNumber, alphaValue: NSNumber) {
+        self.name = name
+        self.redValue = redValue
+        self.greenValue = greenValue
+        self.blueValue = blueValue
+        self.alphaValue = alphaValue
+    }
+    
+}


### PR DESCRIPTION
**Description**
- `HHHueModel`: A model with properties to represent the red, green, blue and alpha values of a color
- `UIColor+RGB`: Contains helper methods to convert the RGBA values of an instance of `UIColor` to different outputs (a swift `[String: CGFloat]` dictionary and instance of `HHHueModel` specifically

**Testing**
- `HHHueModelTest`: All tests pass
- `UIColor+RGBTest`: All tests pass